### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# v0.2.0
+
+## Breaking
+
+- The IME trait was updated to support more features
+
+## Features
+
+- Configuring the IME via TextConfig is now supported (`Ime::get_text_config`)
+- Receiving the enter key type is now supported (`Ime::send_enter_key`)
+
+## Fixes
+
+- ImeProxy is now properly unregistered from the dispatcher when it is dropped

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "ohos-ime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "ohos-ime-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ohos-ime"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Bindings to the `inputmethod` API of OpenHarmony"
 license = "Apache-2.0"

--- a/src/text_config.rs
+++ b/src/text_config.rs
@@ -1,0 +1,102 @@
+use std::num::TryFromIntError;
+// use std::ptr::NonNull;
+// use ohos_ime_sys::text_config::{InputMethod_TextConfig, OH_TextConfig_Create, OH_TextConfig_Destroy, OH_TextConfig_SetEnterKeyType, OH_TextConfig_SetInputType, OH_TextConfig_SetPreviewTextSupport, OH_TextConfig_SetSelection, OH_TextConfig_SetWindowId};
+use ohos_ime_sys::types::{InputMethod_EnterKeyType, InputMethod_TextInputType};
+
+#[derive(Clone)]
+pub struct TextSelection {
+    pub(crate) start: i32,
+    pub(crate) end: i32,
+}
+
+pub struct InvalidSelection(());
+
+impl From<TryFromIntError> for InvalidSelection {
+    fn from(_: TryFromIntError) -> Self {
+        InvalidSelection(())
+    }
+}
+
+impl TextSelection {
+    // Todo: Since we have utf-8 rust strings, but use utf-16 on the arkts side, do the indexes perhaps
+    // need to be updated for cases where 2 utf-8 codepoints map to 1 utf-16 codepoint?
+    // But we don't have any information about the string here, so I guess we would need to
+    // impose this as a usage requirement on the user.
+    /// Create a new Text Selection.
+    pub fn new(start: usize, end: usize) -> Result<TextSelection, InvalidSelection> {
+        Ok(TextSelection {
+            start: start.try_into()?,
+            end: end.try_into()?,
+        })
+    }
+}
+
+pub struct TextConfig {
+    pub(crate) input_type: InputMethod_TextInputType,
+    pub(crate) enterkey_type: InputMethod_EnterKeyType,
+    pub(crate) preview_text_support: bool,
+    pub(crate) selection: Option<TextSelection>,
+    pub(crate) window_id: Option<i32>,
+}
+
+impl Default for TextConfig {
+    fn default() -> TextConfig {
+        TextConfigBuilder::new().build()
+    }
+}
+
+pub struct TextConfigBuilder {
+    input_type: InputMethod_TextInputType,
+    enterkey_type: InputMethod_EnterKeyType,
+    preview_text_support: bool,
+    selection: Option<TextSelection>,
+    window_id: Option<i32>,
+}
+
+impl TextConfigBuilder {
+    pub fn new() -> TextConfigBuilder {
+        TextConfigBuilder {
+            input_type: InputMethod_TextInputType::IME_TEXT_INPUT_TYPE_TEXT,
+            enterkey_type: InputMethod_EnterKeyType::IME_ENTER_KEY_UNSPECIFIED,
+            preview_text_support: false,
+            selection: None,
+            window_id: None,
+        }
+    }
+
+    pub fn build(&self) -> TextConfig {
+        TextConfig {
+            // raw: config,
+            input_type: self.input_type.clone(),
+            enterkey_type: self.enterkey_type.clone(),
+            preview_text_support: self.preview_text_support,
+            selection: self.selection.clone(),
+            window_id: self.window_id,
+        }
+    }
+
+    pub fn input_type(mut self, input_type: InputMethod_TextInputType) -> TextConfigBuilder {
+        self.input_type = input_type;
+        self
+    }
+
+    pub fn enterkey_type(mut self, enterkey_type: InputMethod_EnterKeyType) -> TextConfigBuilder {
+        self.enterkey_type = enterkey_type;
+        self
+    }
+
+    pub fn preview_text_support(mut self, preview_text_support: bool) -> TextConfigBuilder {
+        self.preview_text_support = preview_text_support;
+        self
+    }
+
+    pub fn selection(mut self, selection: TextSelection) -> TextConfigBuilder {
+        self.selection = Some(selection);
+        self
+    }
+
+    pub fn window_id(mut self, window_id: i32) -> TextConfigBuilder {
+        self.window_id = Some(window_id);
+        self
+    }
+}

--- a/src/text_editor.rs
+++ b/src/text_editor.rs
@@ -1,8 +1,14 @@
+// TODO:
+// - switch to parking lot and uns MutexGuard::map or owning_ref to reduce some of duplicate code here.
 #![allow(unused)]
+pub use crate::text_config::{TextConfig, TextConfigBuilder};
 use crate::Ime;
 use log::{debug, error, info, trace, warn};
 use ohos_ime_sys::private_command::InputMethod_PrivateCommand;
-use ohos_ime_sys::text_config::InputMethod_TextConfig;
+use ohos_ime_sys::text_config::{
+    InputMethod_TextConfig, OH_TextConfig_SetEnterKeyType, OH_TextConfig_SetInputType,
+    OH_TextConfig_SetPreviewTextSupport, OH_TextConfig_SetSelection, OH_TextConfig_SetWindowId,
+};
 use ohos_ime_sys::text_editor_proxy::InputMethod_TextEditorProxy;
 use ohos_ime_sys::types::{
     InputMethod_Direction, InputMethod_EnterKeyType, InputMethod_ExtendAction,
@@ -13,6 +19,13 @@ use std::ptr::{slice_from_raw_parts, NonNull};
 use std::sync::{RwLock, RwLockReadGuard};
 
 pub(crate) static DISPATCHER: Dispatcher = Dispatcher::new();
+
+#[derive(Debug)]
+pub(crate) enum DispatcherError {
+    Uninitialized,
+    NotFound,
+    LockPoisoned,
+}
 
 pub(crate) struct Dispatcher {
     map: RwLock<Option<HashMap<usize, Box<dyn super::Ime>>>>,
@@ -31,22 +44,33 @@ impl Dispatcher {
         c_proxy: NonNull<InputMethod_TextEditorProxy>,
         ime: Box<dyn Ime>,
     ) {
+        debug!("Registering IME");
+        // Todo: remove unwrap and make register() fallible.
         let mut map = self.map.write().unwrap();
-        info!("Registering ime | IME");
         let res = map
             .get_or_insert_with(HashMap::new)
             .insert(c_proxy.as_ptr() as usize, ime);
         if res.is_some() {
-            error!("Double insert of IME text editor?");
-            panic!("Double insert of IME text editor?")
+            warn!("Double insert of IME text editor. Dropping the old one");
         }
     }
 
-    fn insert_text(
+    pub(crate) fn unregister(
         &self,
-        text_editor_proxy: *mut InputMethod_TextEditorProxy,
-        text: &[u16],
-    ) {
+        c_proxy: NonNull<InputMethod_TextEditorProxy>,
+    ) -> Result<Box<dyn Ime>, DispatcherError> {
+        debug!("Unregistering IME");
+        let mut map = self
+            .map
+            .write()
+            .map_err(|_| DispatcherError::LockPoisoned)?;
+        map.as_mut()
+            .ok_or(DispatcherError::Uninitialized)?
+            .remove(&(c_proxy.as_ptr() as usize))
+            .ok_or(DispatcherError::NotFound)
+    }
+
+    fn insert_text(&self, text_editor_proxy: *mut InputMethod_TextEditorProxy, text: &[u16]) {
         let map = self.map.read().unwrap();
         let ime = map
             .as_ref()
@@ -101,13 +125,98 @@ impl Dispatcher {
             }
         }
     }
+
+    fn get_text_config(
+        &self,
+        text_editor_proxy: *mut InputMethod_TextEditorProxy,
+        oh_config: *mut InputMethod_TextConfig,
+    ) {
+        let map = self.map.read().unwrap();
+        let ime = map
+            .as_ref()
+            .and_then(|m| m.get(&(text_editor_proxy as usize)));
+        match ime {
+            Some(ime) => {
+                let config = ime.get_text_config();
+                if let Err(e) = apply_text_config(config, oh_config) {
+                    error!("Failed to apply IME config in `get_text_config`: {e:?}");
+                }
+            }
+            None => {
+                error!("IME dispatcher called, but no IME implementation registered!")
+            }
+        }
+    }
+
+    fn send_enter_key(
+        &self,
+        text_editor_proxy: *mut InputMethod_TextEditorProxy,
+        enter_key_type: InputMethod_EnterKeyType,
+    ) {
+        let map = self.map.read().unwrap();
+        let ime = map
+            .as_ref()
+            .and_then(|m| m.get(&(text_editor_proxy as usize)));
+        match ime {
+            Some(ime) => {
+                ime.send_enter_key(enter_key_type);
+            }
+            None => {
+                error!("IME dispatcher called, but no IME implementation registered!")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ApplyTextConfigError {
+    SetInputTypeFailed,
+    SetEnterKeyTypeFailed,
+    SetPreviewTextSupportFailed,
+    SetSelectioFailed,
+    SetWindowIdFailed,
+}
+
+fn apply_text_config(
+    config: &TextConfig,
+    oh_config: *mut InputMethod_TextConfig,
+) -> Result<(), ApplyTextConfigError> {
+    unsafe {
+        let res = OH_TextConfig_SetInputType(oh_config, config.input_type.clone());
+        if !res.is_ok() {
+            return Err(ApplyTextConfigError::SetInputTypeFailed);
+        }
+        let res = OH_TextConfig_SetEnterKeyType(oh_config, config.enterkey_type.clone());
+        if !res.is_ok() {
+            return Err(ApplyTextConfigError::SetEnterKeyTypeFailed);
+        }
+        let res = OH_TextConfig_SetPreviewTextSupport(oh_config, config.preview_text_support);
+        if !res.is_ok() {
+            return Err(ApplyTextConfigError::SetPreviewTextSupportFailed);
+        }
+        if let Some(selection) = &config.selection {
+            let res = OH_TextConfig_SetSelection(oh_config, selection.start, selection.end);
+            if !res.is_ok() {
+                return Err(ApplyTextConfigError::SetSelectioFailed);
+            }
+        }
+        if let Some(window_id) = config.window_id {
+            // let's see if this is optional...
+            let res = OH_TextConfig_SetWindowId(oh_config, window_id);
+            if !res.is_ok() {
+                return Err(ApplyTextConfigError::SetWindowIdFailed);
+            }
+        }
+    }
+    Ok(())
 }
 
 pub extern "C" fn get_text_config(
     text_editor_proxy: *mut InputMethod_TextEditorProxy,
     config: *mut InputMethod_TextConfig,
 ) {
-    error!("get_text_config not implemented");
+    info!("get_text_config: Getting IME text config");
+    DISPATCHER.get_text_config(text_editor_proxy, config);
 }
 
 pub extern "C" fn insert_text(
@@ -142,14 +251,17 @@ pub extern "C" fn send_keyboard_status(
     text_editor_proxy: *mut InputMethod_TextEditorProxy,
     keyboard_status: InputMethod_KeyboardStatus,
 ) {
-    error!("send_keyboard_status not implemented");
+    error!(
+        "send_keyboard_status not implemented. IME keyboard status: {}",
+        keyboard_status.0
+    );
 }
 
 pub extern "C" fn send_enter_key(
     text_editor_proxy: *mut InputMethod_TextEditorProxy,
     enter_key_type: InputMethod_EnterKeyType,
 ) {
-    error!("send_enter_key not implemented");
+    DISPATCHER.send_enter_key(text_editor_proxy, enter_key_type);
 }
 
 pub extern "C" fn move_cursor(


### PR DESCRIPTION
## Breaking

- The IME trait was updated to support more features

## Features

- Configuring the IME via TextConfig is now supported (`Ime::get_text_config`)
- Receiving the enter key type is now supported (`Ime::send_enter_key`)

## Fixes

- ImeProxy is now properly unregistered from the dispatcher when it is dropped