### PR TITLE
Register the dispatcher while creating RawTextEditorProxy.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ohos-ime"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Bindings to the `inputmethod` API of OpenHarmony"
 license = "Apache-2.0"


### PR DESCRIPTION
This makes sure that dispatcher is registered before registering the TextEditorProxy callbacks.

And bump up the version to v0.2.1.