### PR TITLE
Fix warning in get_left_text_of_cursor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,6 @@
 //!
 //! 1. Implement the Ime trait
 //! 2. call `ImeProxy::new()`
-//!
-//!
-
 mod text_config;
 mod text_editor;
 

--- a/src/text_editor.rs
+++ b/src/text_editor.rs
@@ -287,6 +287,10 @@ pub extern "C" fn get_left_text_of_cursor(
     length: *mut usize,
 ) {
     error!("get_left_text_of_cursor not implemented");
+    unsafe {
+        *text = 0;
+        *length = 1;
+    }
 }
 
 pub extern "C" fn get_right_text_of_cursor(
@@ -296,6 +300,10 @@ pub extern "C" fn get_right_text_of_cursor(
     length: *mut usize,
 ) {
     error!("get_right_text_of_cursor not implemented");
+    unsafe {
+        *text = 0;
+        *length = 1;
+    }
 }
 
 pub extern "C" fn get_text_index_at_cursor(


### PR DESCRIPTION
Properly implement the stub to avoid warnings.